### PR TITLE
Make `org.gradle.category` a strongly recomended attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you are a plugin author, please contribute to this repository by documenting 
   - [Source code](https://github.com/gradle/gradle/blob/master/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java)
   - [Documentation](https://docs.gradle.org/nightly/javadoc/org/gradle/api/attributes/Usage.html)
   - Setting this attribute is strongly recommended.
-  - If developing a third party plugin that needs to avoid clashing with other attributes, using reverse DNS naming is recommended.
+  - If developing a third party plugin that needs to avoid clashing with other attributes, using [reverse DNS naming](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) is recommended.
   - Gradle known values 
     - `java-runtime`
     - `java-api`
@@ -29,7 +29,7 @@ If you are a plugin author, please contribute to this repository by documenting 
   - [Source code](https://github.com/gradle/gradle/blob/master/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java)
   - [Documentation](https://docs.gradle.org/nightly/javadoc/org/gradle/api/attributes/Category.html)
   - Setting this attribute is strongly recommended.
-  - If developing a third party plugin that needs to avoid clashing with other attributes, using reverse DNS naming is recommended.
+  - If developing a third party plugin that needs to avoid clashing with other attributes, using [reverse DNS naming](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) is recommended.
   - Gradle known values
     - `documentation`
     - `library`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ If you are a plugin author, please contribute to this repository by documenting 
     - `native-runtime`
     - `swift-api`
     - `version-catalog`
+  - Example third party value
+    - `com.example.usage.metadata` 
 - `org.gradle.category` 
   - [Source code](https://github.com/gradle/gradle/blob/master/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java)
   - [Documentation](https://docs.gradle.org/nightly/javadoc/org/gradle/api/attributes/Category.html)
@@ -36,6 +38,8 @@ If you are a plugin author, please contribute to this repository by documenting 
     - `platform`
     - `enforced-platform`
     - `verification`
+  - Example third party value
+    - `com.example.category.metadata` 
 - `org.gradle.dependency.bundling`
   - [Source code](https://github.com/gradle/gradle/blob/master/subprojects/core-api/src/main/java/org/gradle/api/attributes/Bundling.java)
   - [Documentation](https://docs.gradle.org/nightly/javadoc/org/gradle/api/attributes/Bundling.html)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ If you are a plugin author, please contribute to this repository by documenting 
   - [Source code](https://github.com/gradle/gradle/blob/master/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java)
   - [Documentation](https://docs.gradle.org/nightly/javadoc/org/gradle/api/attributes/Usage.html)
   - Setting this attribute is strongly recommended.
-  - Known values
+  - If developing a third party plugin that needs to avoid clashing with other attributes, using reverse DNS naming is recommended.
+  - Gradle known values 
     - `java-runtime`
     - `java-api`
     - `kotlin-metadata`
@@ -27,7 +28,9 @@ If you are a plugin author, please contribute to this repository by documenting 
 - `org.gradle.category` 
   - [Source code](https://github.com/gradle/gradle/blob/master/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java)
   - [Documentation](https://docs.gradle.org/nightly/javadoc/org/gradle/api/attributes/Category.html)
-  - Known values
+  - Setting this attribute is strongly recommended.
+  - If developing a third party plugin that needs to avoid clashing with other attributes, using reverse DNS naming is recommended.
+  - Gradle known values
     - `documentation`
     - `library`
     - `platform`


### PR DESCRIPTION
See https://github.com/gradle/gradle/issues/36934#issuecomment-3996400168

Also recomend reverse DNS for third party plugins that need to avoid clashes.